### PR TITLE
Handle disconnection

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -39,11 +39,12 @@ class Player(Base):
     answer = Column(String)
     hearts = Column(Integer)
     death_at = Column(Integer)
+    disconnected = Column(Integer, default=0)
 
     player = relationship("Room", back_populates="players")
 
     def __repr__(self) -> str:
-        return f"Player(name={self.name}, sid={self.sid}, answer={self.answer}, hearts={self.hearts}, death_at={self.death_at})"
+        return f"Player(name={self.name}, sid={self.sid}, answer={self.answer}, hearts={self.hearts}, death_at={self.death_at}, disconnected={self.disconnected == 1})"
 
     def to_dict(self) -> dict:
         return {
@@ -52,6 +53,7 @@ class Player(Base):
             "answer": self.answer,
             "hearts": self.hearts,
             "deathAt": self.death_at,
+            "disconnected": self.disconnected == 1,
         }
 
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,11 @@ export default Vue.extend({
       },
       false
     );
+
+    // Emit a disconnect event when the client leave the page
+    window.addEventListener("beforeunload", () => {
+      this.$socket.disconnect();
+    });
   },
 });
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,5 +51,16 @@ new Vue({
     connect: () => {
       console.log("Connected");
     },
+    adminDisconnect: () => {
+      console.log("The admin leave the room...");
+      router.push({ name: "home", params: { auto: "true" } });
+    },
+    disconnect: () => {
+      console.log("You've been disconnected...");
+      router.push({
+        name: "home",
+        params: { auto: "true" },
+      });
+    },
   },
 }).$mount("#app");


### PR DESCRIPTION
- Les joueurs déconnectés n'apparaissent pas dans la salle d'attente.
- Un joueur déconnecté peut reprendre son pseudo s'il rentre dans la partie avant qu'elle soit verrouillé.
- Si l'admin de la partie se fait déconnecter. Tous les joueurs sont déconnectés
- Toutes les entités du jeu une fois déconnecté se retrouve à la page du site