### PR TITLE
Fix du classement

### DIFF
--- a/src/views/LeaderboardView.vue
+++ b/src/views/LeaderboardView.vue
@@ -114,6 +114,8 @@ export default class Leaderboard extends Vue {
         (p1: Player, p2: Player) => {
           if (p1.deathAt < p2.deathAt) return 1; // Sort in dsc order
           if (p1.deathAt > p2.deathAt) return -1;
+          if (p1.hearts < p2.hearts) return 1;
+          if (p1.hearts > p2.hearts) return -1;
           return 0;
         }
       );


### PR DESCRIPTION
- Tri des joueurs par ordre décroisant des tours
- tri des joueurs en fonction des vies restantes si il y a égalité
![image](https://user-images.githubusercontent.com/36128190/171097507-053c9fa8-c0d6-4fe1-8c30-d10d93c0a355.png)
